### PR TITLE
Theme bug

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link as GatsbyLink } from 'gatsby';
 import {
   useColorMode,
@@ -20,6 +20,12 @@ import siteIcon from '../../content/assets/bodybuilding.png';
 const Header = ({ isHome }) => {
   const { title, snsAccounts } = useSiteMetadata();
   const { colorMode, toggleColorMode } = useColorMode();
+
+  // Note: Workaround this bug https://github.com/YuukiOkamoto/my-blog/issues/14
+  const [, setHasRendered] = useState(false);
+  useEffect(() => {
+    if (colorMode === 'dark') setHasRendered(true);
+  }, []);
 
   const HeaderIconButton = ({ bgColor, ...props }) => (
     <IconButton

--- a/src/components/MDX/Callout.js
+++ b/src/components/MDX/Callout.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { useColorMode, Stack, Text } from '@chakra-ui/core';
+
+const Callout = ({ emoji, children, ...props }) => {
+  const { colorMode } = useColorMode();
+
+  // Note: Workaround this bug https://github.com/YuukiOkamoto/my-blog/issues/14
+  const [bg, setBg] = useState('');
+  useEffect(() => {
+    setBg({ light: 'gray.100', dark: 'gray.700' }[colorMode]);
+  }, [colorMode]);
+
+  return (
+    <Stack
+      isInline
+      d='inline-flex'
+      spacing='3'
+      align='center'
+      bg={bg}
+      py='2'
+      px='4'
+      borderRadius='lg'
+      {...props}
+    >
+      <Text fontSize='3xl'>{emoji}</Text>
+      <Text wordBreak='break-word'>
+        {children}
+      </Text>
+    </Stack>
+  );
+};
+
+export default Callout;

--- a/src/components/MDX/index.js
+++ b/src/components/MDX/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
 import {
   Code,
   Divider,

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { useColorMode, Box, Flex } from '@chakra-ui/core';
+import React　from 'react';
+import { Box, Flex } from '@chakra-ui/core';
 
 import Header from './Header';
 import Footer from './Footer';
@@ -7,14 +7,6 @@ import Footer from './Footer';
 const Layout = ({ location, children }) => {
   const rootPath = `${__PATH_PREFIX__}/`;
   const isHome = location.pathname === rootPath;
-
-  const { colorMode } = useColorMode();
-  const [, setHasRendered] = useState(false);
-
-  // Workaround this bug: https://github.com/chakra-ui/chakra-ui/issues/511
-  useEffect(() => {
-    if (colorMode === 'dark') setHasRendered(true);
-  }, []);
 
   return (
     <Flex direction='column' minH='100vh' mx='auto'>


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
このバグの対応2種類。
https://github.com/YuukiOkamoto/my-blog/issues/14

> デフォがダークモードのクライアントにおいて、
初期レンダリング時にcolorModeがdarkに変わっても、
Chakraのコンポーネントが再レンダリングされず、SSGしたときのlightテーマのstyleのまま表示されてしまう。

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
1.  初回ダークモード時のみ、強制的にコンポーネントを再レンダリングする方法（Header)
2. それでもだめな場合、使う色をstateで管理し、colorModeが変更されるたびに変更する方法（Callout）
